### PR TITLE
Add user station counts and discount flag

### DIFF
--- a/src/main/java/pt/ua/tqs/voltconnect/models/Reservation.java
+++ b/src/main/java/pt/ua/tqs/voltconnect/models/Reservation.java
@@ -26,7 +26,11 @@ public class Reservation {
 
     private Date startTime;
     
-    private Long chargingTime; 
+    private Long chargingTime;
 
     private Double price;
+
+    private Double originalPrice;
+
+    private boolean discount;
 }

--- a/src/main/java/pt/ua/tqs/voltconnect/models/User.java
+++ b/src/main/java/pt/ua/tqs/voltconnect/models/User.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import java.util.Map;
+import java.util.HashMap;
 
 @Entity
 @Table(name = "app_user")
@@ -26,6 +28,13 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    @ElementCollection
+    @CollectionTable(name = "user_station_count", joinColumns = @JoinColumn(name = "user_id"))
+    @MapKeyColumn(name = "station_id")
+    @Column(name = "reservation_count")
+    @Builder.Default
+    private Map<Long, Integer> stationReservationsCount = new HashMap<>();
 
     public enum Role {
         DRIVER, OPERATOR, TECHNICIAN, ADMIN

--- a/src/test/java/pt/ua/tqs/voltconnect/services/ReservationServiceTest.java
+++ b/src/test/java/pt/ua/tqs/voltconnect/services/ReservationServiceTest.java
@@ -32,6 +32,9 @@ class ReservationServiceTest {
     @Mock
     private VehicleRepository vehicleRepository;
 
+    @Mock
+    private UserRepository userRepository;
+
     @InjectMocks
     private ReservationServiceImpl reservationService;
 
@@ -42,6 +45,7 @@ class ReservationServiceTest {
     private Vehicle vehicleWithAC;
     private Vehicle vehicleWithDC;
     private Vehicle vehicleWithNoCharger;
+    private User user;
 
     @BeforeEach
     void setUp() {
@@ -52,6 +56,10 @@ class ReservationServiceTest {
                 .chargerId(100L)
                 .startTime(new Date(System.currentTimeMillis() + 3600_000))
                 .build();
+
+        user = new User();
+        user.setId(1L);
+        user.setStationReservationsCount(new HashMap<>());
 
         chargerAC = new Charger();
         chargerAC.setId(100L);
@@ -87,6 +95,8 @@ class ReservationServiceTest {
         vehicleWithNoCharger.setUsableBatterySize(42.2);
         vehicleWithNoCharger.setAcChargerJson(null);
         vehicleWithNoCharger.setDcChargerJson(null);
+
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
     }
 
     @Test
@@ -243,6 +253,26 @@ class ReservationServiceTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, 
             () -> reservationService.createReservation(reservation));
         assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    @Test
+    void createReservation_FourthTimeDiscountApplied() {
+        reservation.setChargerId(chargerAC.getId());
+        reservation.setVehicleId(vehicleWithAC.getId());
+        user.getStationReservationsCount().put(station.getId(), 3);
+
+        when(chargingStationRepository.findById(station.getId())).thenReturn(Optional.of(station));
+        when(vehicleRepository.findById(vehicleWithAC.getId())).thenReturn(Optional.of(vehicleWithAC));
+        when(reservationRepository.findByChargerId(chargerAC.getId())).thenReturn(Collections.emptyList());
+        when(reservationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        Reservation result = reservationService.createReservation(reservation);
+
+        assertTrue(result.isDiscount());
+        double expectedOriginalPrice = vehicleWithAC.getUsableBatterySize() * chargerAC.getPricePerKWh();
+        assertEquals(expectedOriginalPrice, result.getOriginalPrice());
+        double expectedDiscounted = Math.round(expectedOriginalPrice * 0.9 * 100.0) / 100.0;
+        assertEquals(expectedDiscounted, result.getPrice());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- track reservation counts per user and station
- set discount flag in Reservation entity when count >= 3
- extend ReservationService to update user counts and set discount
- add test coverage for the discount logic
- store original price and apply discount starting from the fourth booking

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_684033a8ab7c8327b4cdf35349f9e158