### PR TITLE
it tests (previous it were controller) and observability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,12 @@
             <artifactId>spring-boot-testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Micrometer Prometheus registry -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/pt/ua/tqs/voltconnect/controllers/ChargerController.java
+++ b/src/main/java/pt/ua/tqs/voltconnect/controllers/ChargerController.java
@@ -7,10 +7,7 @@ import pt.ua.tqs.voltconnect.models.Charger;
 import pt.ua.tqs.voltconnect.models.ChargingStation;
 import pt.ua.tqs.voltconnect.services.ChargerService;
 import pt.ua.tqs.voltconnect.services.ChargingStationService;
-import pt.ua.tqs.voltconnect.repositories.ChargerRepository;
-import pt.ua.tqs.voltconnect.repositories.ChargingStationRepository;
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/chargers")

--- a/src/main/java/pt/ua/tqs/voltconnect/controllers/VehicleController.java
+++ b/src/main/java/pt/ua/tqs/voltconnect/controllers/VehicleController.java
@@ -28,7 +28,11 @@ public class VehicleController {
 
     @GetMapping("/brand/{name}")
     public ResponseEntity<List<VehicleDTO>> getByBrand(@PathVariable String name) {
-        return ResponseEntity.ok(vehicleService.getVehiclesByBrand(name));
+        List<VehicleDTO> vehicles = vehicleService.getVehiclesByBrand(name);
+        if (vehicles.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(vehicles);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/pt/ua/tqs/voltconnect/models/Brand.java
+++ b/src/main/java/pt/ua/tqs/voltconnect/models/Brand.java
@@ -14,12 +14,18 @@ import java.util.List;
 public class Brand {
 
     @Id
-    private String id;  // UUID da API
+    private String id;
 
     private String name;
 
     private String modelsFile;
 
+    /**
+     * Bidirectional relationship with Vehicle.
+     * This circular dependency is intentional and required for JPA entity mapping.
+     * Serialization issues are handled with @JsonManagedReference/@JsonBackReference.
+     * See SonarQube issue: this is a justified exception for ORM navigation.
+     */
     @OneToMany(mappedBy = "brand", cascade = CascadeType.ALL)
     @JsonManagedReference
     private List<Vehicle> vehicles;

--- a/src/main/java/pt/ua/tqs/voltconnect/models/Vehicle.java
+++ b/src/main/java/pt/ua/tqs/voltconnect/models/Vehicle.java
@@ -15,6 +15,12 @@ public class Vehicle {
 
     @Id
     private String id;
+    /**
+     * Bidirectional relationship with Brand.
+     * This circular dependency is intentional and required for JPA entity mapping.
+     * Serialization issues are handled with @JsonBackReference/@JsonManagedReference.
+     * See SonarQube issue: this is a justified exception for ORM navigation.
+     */
     @ManyToOne
     @JoinColumn(name = "brand_id")
     @JsonBackReference

--- a/src/main/java/pt/ua/tqs/voltconnect/services/StartupService.java
+++ b/src/main/java/pt/ua/tqs/voltconnect/services/StartupService.java
@@ -1,6 +1,8 @@
 package pt.ua.tqs.voltconnect.services;
 
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.context.annotation.Profile;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.lang.NonNull;
@@ -8,6 +10,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile("!test")
 @RequiredArgsConstructor
 public class StartupService implements ApplicationListener<ApplicationReadyEvent> {
 

--- a/src/main/java/pt/ua/tqs/voltconnect/services/impl/BrandServiceImpl.java
+++ b/src/main/java/pt/ua/tqs/voltconnect/services/impl/BrandServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.web.client.RestTemplate;
 import pt.ua.tqs.voltconnect.dtos.BrandDTO;
 import pt.ua.tqs.voltconnect.models.Brand;
 import pt.ua.tqs.voltconnect.repositories.BrandRepository;
+import pt.ua.tqs.voltconnect.repositories.VehicleRepository;
 import pt.ua.tqs.voltconnect.services.BrandService;
 
 import java.util.List;
@@ -19,6 +20,7 @@ import java.util.List;
 public class BrandServiceImpl implements BrandService {
 
     private final BrandRepository brandRepository;
+    private final VehicleRepository vehicleRepository;
     private final RestTemplate restTemplate;
 
     @Value("${external.api.brands-url}")
@@ -60,6 +62,7 @@ public class BrandServiceImpl implements BrandService {
         }
 
         if (force) {
+            vehicleRepository.deleteAll();
             brandRepository.deleteAll();
         }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,6 @@ logging.level.org.hibernate.type.descriptor.sql.BasicBinder=warn
 logging.level.org.springframework.orm.jpa.JpaTransactionManager=warn
 logging.level.org.springframework.jdbc.datasource.DataSourceUtils=warn
 logging.level.org.springframework.web.client.RestTemplate=warn
+
+management.endpoints.web.exposure.include=health,info,prometheus
+management.endpoint.prometheus.enabled=true

--- a/src/test/java/pt/ua/tqs/voltconnect/controllers/BrandControllerIntegrationTest.java
+++ b/src/test/java/pt/ua/tqs/voltconnect/controllers/BrandControllerIntegrationTest.java
@@ -1,4 +1,4 @@
-package pt.ua.tqs.voltconnect.integration;
+package pt.ua.tqs.voltconnect.controllers;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -7,7 +7,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.client.RestTemplate;
-import pt.ua.tqs.voltconnect.controllers.BrandController;
 import pt.ua.tqs.voltconnect.dtos.BrandDTO;
 import pt.ua.tqs.voltconnect.services.BrandService;
 

--- a/src/test/java/pt/ua/tqs/voltconnect/controllers/ChargerControllerTest.java
+++ b/src/test/java/pt/ua/tqs/voltconnect/controllers/ChargerControllerTest.java
@@ -147,7 +147,9 @@ class ChargerControllerTest {
         ResponseEntity<Charger> response = chargerController.updateCharger(chargerId, updatedCharger);
 
         assertEquals(200, response.getStatusCode().value());
-        assertEquals(Charger.Type.DC, response.getBody().getChargerType());
+        Charger responseBody = response.getBody();
+        assertNotNull(responseBody);
+        assertEquals(Charger.Type.DC, responseBody.getChargerType());
         verify(chargerService, times(1)).getChargerById(chargerId);
         verify(chargerService, times(1)).saveCharger(existingCharger);
     }

--- a/src/test/java/pt/ua/tqs/voltconnect/controllers/ChargingStationControllerTest.java
+++ b/src/test/java/pt/ua/tqs/voltconnect/controllers/ChargingStationControllerTest.java
@@ -1,4 +1,4 @@
-package pt.ua.tqs.voltconnect.integration;
+package pt.ua.tqs.voltconnect.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,7 +8,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import pt.ua.tqs.voltconnect.controllers.ChargingStationController;
 import pt.ua.tqs.voltconnect.models.ChargingStation;
 import pt.ua.tqs.voltconnect.services.ChargingStationService;
 import static org.mockito.Mockito.doThrow;
@@ -21,7 +20,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ChargingStationController.class)
-class ChargingStationControllerIntegrationTest {
+class ChargingStationControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/pt/ua/tqs/voltconnect/controllers/ReservationControllerTest.java
+++ b/src/test/java/pt/ua/tqs/voltconnect/controllers/ReservationControllerTest.java
@@ -1,4 +1,4 @@
-package pt.ua.tqs.voltconnect.integration;
+package pt.ua.tqs.voltconnect.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,7 +8,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import pt.ua.tqs.voltconnect.controllers.ReservationController;
 import pt.ua.tqs.voltconnect.models.Reservation;
 import pt.ua.tqs.voltconnect.services.ReservationService;
 
@@ -23,7 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ReservationController.class)
-class ReservationControllerIntegrationTest {
+class ReservationControllerTest {
 
         @Autowired
         private MockMvc mockMvc;

--- a/src/test/java/pt/ua/tqs/voltconnect/controllers/ReviewControllerTest.java
+++ b/src/test/java/pt/ua/tqs/voltconnect/controllers/ReviewControllerTest.java
@@ -1,4 +1,4 @@
-package pt.ua.tqs.voltconnect.integration;
+package pt.ua.tqs.voltconnect.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,7 +8,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import pt.ua.tqs.voltconnect.controllers.ReviewController;
 import pt.ua.tqs.voltconnect.dtos.ReviewRequestDTO;
 import pt.ua.tqs.voltconnect.models.ChargingStation;
 import pt.ua.tqs.voltconnect.models.Review;
@@ -23,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.mockito.Mockito.doThrow;
 
 @WebMvcTest(ReviewController.class)
-class ReviewControllerIntegrationTest {
+class ReviewControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/pt/ua/tqs/voltconnect/controllers/UserControllerTest.java
+++ b/src/test/java/pt/ua/tqs/voltconnect/controllers/UserControllerTest.java
@@ -1,4 +1,4 @@
-package pt.ua.tqs.voltconnect.integration;
+package pt.ua.tqs.voltconnect.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,7 +8,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import pt.ua.tqs.voltconnect.controllers.UserController;
 import pt.ua.tqs.voltconnect.models.User;
 import pt.ua.tqs.voltconnect.services.UserService;
 
@@ -21,7 +20,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(UserController.class)
-class UserControllerIntegrationTest {
+class UserControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/pt/ua/tqs/voltconnect/controllers/VehicleControllerTest.java
+++ b/src/test/java/pt/ua/tqs/voltconnect/controllers/VehicleControllerTest.java
@@ -12,6 +12,7 @@ import pt.ua.tqs.voltconnect.services.VehicleService;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -84,6 +85,14 @@ class VehicleControllerTest {
         assertEquals(1, responseBody.size());
         assertEquals(vehicleDTO.getId(), responseBody.get(0).getId());
         verify(vehicleService, times(1)).getVehiclesByBrand("Test Brand");
+    }
+
+    @Test
+    void getByBrand_WhenNoVehiclesFound_ShouldReturnNotFound() {
+        when(vehicleService.getVehiclesByBrand("Test Brand")).thenReturn(Collections.emptyList());
+        ResponseEntity<List<VehicleDTO>> response = vehicleController.getByBrand("Test Brand");
+        assertTrue(response.getStatusCode().is4xxClientError());
+        assertNull(response.getBody());
     }
 
     @Test

--- a/src/test/java/pt/ua/tqs/voltconnect/integration/BrandControllerIT.java
+++ b/src/test/java/pt/ua/tqs/voltconnect/integration/BrandControllerIT.java
@@ -1,0 +1,46 @@
+package pt.ua.tqs.voltconnect.integration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.*;
+import pt.ua.tqs.voltconnect.dtos.BrandDTO;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class BrandControllerIT {
+
+    @LocalServerPort
+    private int randomServerPort;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private String getUrl(String path) {
+        return "http://localhost:" + randomServerPort + "/api/brands" + path;
+    }
+
+    @Test
+    void whenImportBrands_thenBrandsAreAvailable() {
+        ResponseEntity<Void> importResponse = restTemplate.postForEntity(getUrl("/import?force=true"), null, Void.class);
+        assertThat(importResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        ResponseEntity<BrandDTO[]> response = restTemplate.getForEntity(getUrl(""), BrandDTO[].class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotEmpty();
+    }
+
+    @Test
+    void whenGetBrandByName_thenReturnMatchingBrand() {
+        restTemplate.postForEntity(getUrl("/import?force=true"), null, Void.class);
+
+        ResponseEntity<BrandDTO[]> response = restTemplate.getForEntity(getUrl("/name/tesla"), BrandDTO[].class);
+        assertThat(response.getStatusCode()).isIn(HttpStatus.OK, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/test/java/pt/ua/tqs/voltconnect/integration/VehicleControllerIT.java
+++ b/src/test/java/pt/ua/tqs/voltconnect/integration/VehicleControllerIT.java
@@ -1,0 +1,52 @@
+package pt.ua.tqs.voltconnect.integration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.*;
+import pt.ua.tqs.voltconnect.dtos.VehicleDTO;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class VehicleControllerIT {
+
+    @LocalServerPort
+    private int randomServerPort;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private String getUrl(String path) {
+        return "http://localhost:" + randomServerPort + "/api/vehicles" + path;
+    }
+
+    @Test
+    void whenImportVehicles_thenVehiclesAreAvailable() {
+        ResponseEntity<Void> importResponse = restTemplate.postForEntity(getUrl("/import?force=true"), null, Void.class);
+        assertThat(importResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        ResponseEntity<VehicleDTO[]> response = restTemplate.getForEntity(getUrl(""), VehicleDTO[].class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotEmpty();
+    }
+
+    @Test
+    void whenGetVehiclesByBrand_thenReturnVehiclesOrNotFound() {
+        restTemplate.postForEntity(getUrl("/import?force=true"), null, Void.class);
+
+        // get vehicles by brand
+        ResponseEntity<VehicleDTO[]> response = restTemplate.getForEntity(getUrl("/brand/Tesla"), VehicleDTO[].class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotEmpty();
+
+        // get vehicles by non existent brand
+        ResponseEntity<VehicleDTO[]> responseNotFound = restTemplate.getForEntity(getUrl("/brand/NonExistentBrand"), VehicleDTO[].class);
+        assertThat(responseNotFound.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/test/java/pt/ua/tqs/voltconnect/services/BrandServiceTest.java
+++ b/src/test/java/pt/ua/tqs/voltconnect/services/BrandServiceTest.java
@@ -14,6 +14,7 @@ import org.springframework.web.client.RestTemplate;
 import pt.ua.tqs.voltconnect.dtos.BrandDTO;
 import pt.ua.tqs.voltconnect.models.Brand;
 import pt.ua.tqs.voltconnect.repositories.BrandRepository;
+import pt.ua.tqs.voltconnect.repositories.VehicleRepository;
 import pt.ua.tqs.voltconnect.services.impl.BrandServiceImpl;
 
 import java.util.Arrays;
@@ -30,6 +31,9 @@ class BrandServiceTest {
 
     @Mock
     private BrandRepository brandRepository;
+
+    @Mock
+    private VehicleRepository vehicleRepository;
 
     @Mock
     private RestTemplate restTemplate;
@@ -135,6 +139,7 @@ class BrandServiceTest {
         
         brandService.importAllBrands(true);
         
+        verify(vehicleRepository, times(1)).deleteAll();
         verify(brandRepository, times(1)).deleteAll();
         verify(brandRepository, times(2)).save(any(Brand.class));
     }
@@ -169,7 +174,8 @@ class BrandServiceTest {
         
         brandService.importAllBrands(true);
         
+        verify(vehicleRepository, times(1)).deleteAll();
         verify(brandRepository, times(1)).deleteAll();
         verify(brandRepository, never()).save(any(Brand.class));
     }
-} 
+}


### PR DESCRIPTION
# Observability support added, IT tests and previois "IT" tests moved to controllers tests

## Description
<!--- Describe your changes in detail. Explain the purpose of this PR and the problem it solves. Include any relevant context or screenshots. -->
This pull request introduces several updates to the VoltConnect project, focusing on dependency additions, improved error handling, bidirectional entity relationships, environment-specific configurations, and restructuring of test files. Below is a categorized summary of the most important changes:

### Dependency and Configuration Updates:
* Added the Micrometer Prometheus registry dependency to `pom.xml` for monitoring and metrics integration. (`[pom.xmlR200-R205](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R200-R205)`)
* Enabled Prometheus endpoint and exposed health, info, and Prometheus management endpoints in `application.properties`. (`[src/main/resources/application.propertiesR24-R26](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R24-R26)`)

### Code Enhancements:
* Updated `VehicleController` to return a `404 Not Found` response when no vehicles are found for a given brand. (`[src/main/java/pt/ua/tqs/voltconnect/controllers/VehicleController.javaL31-R35](diffhunk://#diff-1050c352d861e807a2983bdde9e0fddf2ef6f4d4c9dfa5e6161a6e43935f8644L31-R35)`)
* Introduced bidirectional relationships between `Brand` and `Vehicle` entities with JPA annotations, justifying the circular dependency for ORM navigation. (`[[1]](diffhunk://#diff-146bf97071641e419553ef7ebf857e531a110ca9e8ce26f9a826d7368ef6242bL17-R28)`, `[[2]](diffhunk://#diff-b5dca0b4a8e9755322dbe05b5aaff4f1a6ff1fd373e66da0f609bf943532375aR18-R23)`)

### Environment-Specific Behavior:
* Added a `@Profile("!test")` annotation to `StartupService` to ensure it only runs in non-test environments. (`[src/main/java/pt/ua/tqs/voltconnect/services/StartupService.javaR4-R13](diffhunk://#diff-8d31868ae0193b9e74107f56f2a44bd84a8c8c010f8faad8c5f1d6731562f832R4-R13)`)

### Test Restructuring:
* Renamed integration test files to better align with their respective controllers (e.g., `BrandControllerIntegrationTest` renamed to `BrandControllerTest`). (`[[1]](diffhunk://#diff-0d621c395b20e4aa193a419991693ab6a49c94c56fc0b261d57c5880f75c0229L1-R1)`, `[[2]](diffhunk://#diff-8f265e7c112fadc9f1a2f0b25695813ad3a709d15821a988e00362359f72038dL1-R1)`, `[[3]](diffhunk://#diff-0092462416ac55147aff4e9250bfae16195ce41a7e900813f67036d08bdc77c4L1-R1)`, `[[4]](diffhunk://#diff-1daee180cbe7fb1168417f39e8a467944c99cd518e87144da481cb080814bcccL1-R1)`, `[[5]](diffhunk://#diff-13c7d2fd67e168f4a715b81ff3f48db723f6bf64bd5830dcf57736d8227b438bL1-R1)`)
* Added new integration tests for `BrandController` and `VehicleController` to validate API behavior. (`[[1]](diffhunk://#diff-51d8aabd89b0b95e73cab81b966bc7624ff56075db432675371ed024a417e416R1-R46)`, `[[2]](diffhunk://#diff-f5637c4711437fd7c6dc4e269ec97f9e2c5929a453523a18e0c5f6bbed194a4eR1-R52)`)

### Repository and Service Updates:
* Added a `VehicleRepository` to `BrandServiceImpl` and ensured vehicles are deleted when brands are forcefully re-imported. (`[[1]](diffhunk://#diff-8b8252f4b510a8b5d6b6be84a6e43a70ce77f7a3d402a2a8e8588af4fb2fc21dR13)`, `[[2]](diffhunk://#diff-8b8252f4b510a8b5d6b6be84a6e43a70ce77f7a3d402a2a8e8588af4fb2fc21dR23)`, `[[3]](diffhunk://#diff-8b8252f4b510a8b5d6b6be84a6e43a70ce77f7a3d402a2a8e8588af4fb2fc21dR65)`)
